### PR TITLE
Bugfix/missing wheel (#1)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,14 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
+
       - name: Install build-time dependencies
         run: pip install --group dist
 
       - name: Build sdist
         run: python -m build --sdist
+
+      - name: Check metadata
+        run: pipx run twine check dist/*
 
       - name: Test sdist
         run: |
@@ -32,24 +39,43 @@ jobs:
         with:
           name: package-sdist
           path: dist/*.tar.gz
+          retention-days: 7
 
   wheels:
-    name: Binary wheels
-    runs-on: ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
+      fail-fast: false
       matrix:
-        os:
-          - windows-11-arm  # Windows arm64 wheels
-          - windows-latest  # Windows x86-64 wheels
-          - ubuntu-latest   # All linux wheels (via emulation)
-          - macos-15-intel  # macOS x86-64 wheels
-          - macos-15        # macOS arm64 wheels
+        include:
+          # Windows
+          - os: windows-x64
+            runs-on: windows-latest
+          - os: windows-arm64
+            runs-on: windows-11-arm
+
+          # Linux
+          - os: linux-x64
+            runs-on: ubuntu-latest
+
+          - os: linux-arm64
+            runs-on: ubuntu-24.04-arm
+
+          # macOS
+          - os: macos-x64
+            runs-on: macos-15-intel
+          - os: macos-arm64
+            runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
+
       - name: Install build-time dependencies
         run: pip install --group dist
 
@@ -71,5 +97,6 @@ jobs:
 
       - uses: actions/upload-artifact@v5
         with:
-          name: package-wheels-${{matrix.os}}
+          name: package-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
+          retention-days: 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
 [dependency-groups]
 dist = [
     "build",
-    "cibuildwheel == 3.1.4",
+    "cibuildwheel == 3.3.1",
 ]
 
 [build-system]
@@ -104,6 +104,7 @@ sdist.exclude = [
 ]
 
 [tool.cibuildwheel]
+build = "cp3{9,10,11,12,13,14}-*"
 enable = [
     "cpython-prerelease",
     "pypy",
@@ -116,11 +117,10 @@ skip = [
 ]
 environment = {CMAKE_GENERATOR="Ninja"}  # Force Ninja even on Windows
 
-# Hardcode manylinux2014 as the target because tool.cibuildwheel.linux uses yum to install packages.
-manylinux-x86_64-image       = "manylinux2014"
-manylinux-aarch64-image      = "manylinux2014"
-manylinux-pypy_x86_64-image  = "manylinux2014"
-manylinux-pypy_aarch64-image = "manylinux2014"
+manylinux-x86_64-image       = "manylinux_2_28"
+manylinux-aarch64-image      = "manylinux_2_28"
+manylinux-pypy_x86_64-image  = "manylinux_2_28"
+manylinux-pypy_aarch64-image = "manylinux_2_28"
 musllinux-x86_64-image       = "musllinux_1_2"
 musllinux-aarch64-image      = "musllinux_1_2"
 
@@ -128,12 +128,18 @@ test-extras = "test"  # Install [test] optional requirements
 test-command = "pytest {project}"
 
 [tool.cibuildwheel.linux]
-before-all = "yum install -y curl zip unzip tar"  # For bootstrapping vcpkg
+before-all = "dnf install -y curl zip unzip tar"  # For bootstrapping vcpkg (manylinux_2_28)
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = "apk add build-base cmake ninja zip unzip curl git"
-environment = {VCPKG_FORCE_SYSTEM_BINARIES="1"}
+environment = {VCPKG_FORCE_SYSTEM_BINARIES="1", CMAKE_POLICY_VERSION_MINIMUM="3.10"}
+
+[[tool.cibuildwheel.overrides]]
+select = "cp39-manylinux*"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+before-all = "yum install -y curl zip unzip tar"  # For bootstrapping vcpkg (manylinux2014)
 
 [tool.pytest.ini_options]
 minversion = "7.0"


### PR DESCRIPTION
* cibuildwheel and manylinux updated

* Added metadata validation and support for Linux ARM

* override cp39 only linux

* add CMAKE_POLICY_VERSION_MINIMUM for CMake 4.x compatibility in musllinux

PR related to the issue #32 